### PR TITLE
1 add fitness overview to various tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ services:
     restart: unless-stopped
     environment:
         - KB_MAIL=<kickbase_email>
-        - KB_PASS=<kickbase_password>
+        - KB_PASSWORD=<kickbase_password>
         - DISCORD_WEBHOOK=<discord_webhook>
         - RUN_SCHEDULE=<your_schedule>
         - WATCHPACK_POLLING=true

--- a/README.md
+++ b/README.md
@@ -84,14 +84,14 @@ To run Kickbase Insights on your local machine, you can follow the steps describ
 
 ## Planned for the future
 **Frontend:**  
-- Market table: Add fitness, maybe ligainsider rating?
-- Lineup planner: Add fitness
+- Market table: Maybe add ligainsider rating?
 - Add battles  
 - Transfererlöse: Hold player for X days  
 - Sum. Transfererlöse: Add custom scale for chart  
 - Dev: Execution time  
 - Misc: Unsold starter players    
 - Display version from container image version   
+- Add stats for users in the league  
 
 **Backend:**  
 - Fix all TODOs  

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -91,7 +91,7 @@ function App() {
             </Grid>
 
             <Grid item sx={{ textAlign: 'right' }}>
-              <Typography variant="button" style={{ color: 'green' }}>V1.1.0</Typography><br/>
+              <Typography variant="button" style={{ color: 'green' }}>V1.2.0</Typography><br/>
               <Typography variant="button" style={{ color: 'green', opacity: '0.7' }}>{new Date(timestamp_main.time).toLocaleString('de-DE')}</Typography>
             </Grid>
           </Grid>

--- a/frontend/src/components/FreePlayersTable.js
+++ b/frontend/src/components/FreePlayersTable.js
@@ -1,6 +1,6 @@
 import { DataGrid } from '@mui/x-data-grid'
 
-import { trendIcons, currencyFormatter } from './SharedConstants'
+import { trendIcons, currencyFormatter, statusIcons } from './SharedConstants'
 
 import data from '../data/free_players.json'
 
@@ -36,6 +36,14 @@ function FreePlayersTable() {
             flex: 2
         },
         {
+            field: "status",
+            headerName: "Status",
+            headerAlign: 'center',
+            align: 'center',
+            flex: 1,
+            renderCell: (params) => statusIcons[params.value]
+        },  
+        {
             field: 'marketValue',
             headerName: 'Marktwert',
             type: 'number',
@@ -67,6 +75,7 @@ function FreePlayersTable() {
             teamLogo: process.env.PUBLIC_URL + "/images/" + row.teamId + ".png",
             firstName: row.firstName,
             lastName: row.lastName,
+            status: row.status,
             marketValue: row.marketValue,
             points: row.points,
             position: row.position,

--- a/frontend/src/components/FreePlayersTable.js
+++ b/frontend/src/components/FreePlayersTable.js
@@ -1,4 +1,5 @@
 import { DataGrid } from '@mui/x-data-grid'
+import Tooltip from '@mui/material/Tooltip'
 
 import { trendIcons, currencyFormatter, statusIcons } from './SharedConstants'
 
@@ -41,7 +42,11 @@ function FreePlayersTable() {
             headerAlign: 'center',
             align: 'center',
             flex: 1,
-            renderCell: (params) => statusIcons[params.value]
+            renderCell: (params) => (
+                <Tooltip title={statusIcons[params.value].tooltip} arrow>
+                    {statusIcons[params.value].icon}
+                </Tooltip>
+            )
         },  
         {
             field: 'marketValue',

--- a/frontend/src/components/LineupPlanner.js
+++ b/frontend/src/components/LineupPlanner.js
@@ -8,6 +8,7 @@ import TextField from '@mui/material/TextField'
 import Grid from '@mui/material/Grid'
 import { NumericFormat } from 'react-number-format'
 import Paper from '@mui/material/Paper'
+import Tooltip from '@mui/material/Tooltip'
 
 import { trendIcons, currencyFormatter, statusIcons } from './SharedConstants'
 
@@ -92,7 +93,11 @@ function LineupPlanner() {
             headerAlign: 'center',
             align: 'center',
             flex: 1,
-            renderCell: (params) => statusIcons[params.value]
+            renderCell: (params) => (
+                <Tooltip title={statusIcons[params.value].tooltip} arrow>
+                    {statusIcons[params.value].icon}
+                </Tooltip>
+            )
         },
         {
             field: 'buyPrice',

--- a/frontend/src/components/LineupPlanner.js
+++ b/frontend/src/components/LineupPlanner.js
@@ -9,7 +9,7 @@ import Grid from '@mui/material/Grid'
 import { NumericFormat } from 'react-number-format'
 import Paper from '@mui/material/Paper'
 
-import { trendIcons, currencyFormatter } from './SharedConstants'
+import { trendIcons, currencyFormatter, statusIcons } from './SharedConstants'
 
 import data from '../data/taken_players.json'
 
@@ -87,6 +87,14 @@ function LineupPlanner() {
             flex: 2
         },
         {
+            field: "status",
+            headerName: "Status",
+            headerAlign: 'center',
+            align: 'center',
+            flex: 1,
+            renderCell: (params) => statusIcons[params.value]
+        },
+        {
             field: 'buyPrice',
             headerName: 'Kaufpreis',
             type: 'number',
@@ -125,6 +133,7 @@ function LineupPlanner() {
             position: row.position,
             firstName: row.firstName,
             lastName: row.lastName,
+            status: row.status,
             buyPrice: row.buyPrice, // row.buyPrice === 0 ? row.market_value : row.buy_price,
             marketValue: row.marketValue,
             turnover: row.buyPrice === 0 ? 0 : row.marketValue - row.buyPrice,

--- a/frontend/src/components/MarketTableKickbase.js
+++ b/frontend/src/components/MarketTableKickbase.js
@@ -1,5 +1,5 @@
 import { DataGrid } from '@mui/x-data-grid'
-import { trendIcons, currencyFormatter } from './SharedConstants'
+import { trendIcons, currencyFormatter, statusIcons } from './SharedConstants'
 
 // Import data
 import data from '../data/market_kickbase.json'
@@ -37,6 +37,14 @@ function MarketTableKickbase() {
             flex: 2
         },
         {
+            field: "status",
+            headerName: "Status",
+            headerAlign: 'center',
+            align: 'center',
+            flex: 1,
+            renderCell: (params) => statusIcons[params.value]
+        },           
+        {
             field: 'price',
             headerName: 'Preis',
             type: 'number',
@@ -71,6 +79,7 @@ function MarketTableKickbase() {
             firstName: row.firstName,
             lastName: row.lastName,
             price: row.price,
+            status: row.status,
             trend: row.trend,
             date: row.expiration
         }

--- a/frontend/src/components/MarketTableKickbase.js
+++ b/frontend/src/components/MarketTableKickbase.js
@@ -1,4 +1,5 @@
 import { DataGrid } from '@mui/x-data-grid'
+import Tooltip from '@mui/material/Tooltip'
 import { trendIcons, currencyFormatter, statusIcons } from './SharedConstants'
 
 // Import data
@@ -42,7 +43,11 @@ function MarketTableKickbase() {
             headerAlign: 'center',
             align: 'center',
             flex: 1,
-            renderCell: (params) => statusIcons[params.value]
+            renderCell: (params) => (
+                <Tooltip title={statusIcons[params.value].tooltip} arrow>
+                    {statusIcons[params.value].icon}
+                </Tooltip>
+            )
         },           
         {
             field: 'price',

--- a/frontend/src/components/MarketTableUser.js
+++ b/frontend/src/components/MarketTableUser.js
@@ -1,5 +1,5 @@
 import { DataGrid } from '@mui/x-data-grid'
-import { trendIcons, currencyFormatter } from './SharedConstants'
+import { trendIcons, currencyFormatter, statusIcons } from './SharedConstants'
 
 // Import data
 import data from '../data/market_user.json'
@@ -36,6 +36,14 @@ function MarketTableUser() {
             align: 'center',
             flex: 2
         },
+        {
+            field: "status",
+            headerName: "Status",
+            headerAlign: 'center',
+            align: 'center',
+            flex: 1,
+            renderCell: (params) => statusIcons[params.value]
+        },           
         {
             field: 'price',
             headerName: 'Preis',
@@ -78,6 +86,7 @@ function MarketTableUser() {
             firstName: row.firstName,
             lastName: row.lastName,
             price: row.price,
+            status: row.status,
             trend: row.trend,
             seller: row.seller,
             date: row.expiration,

--- a/frontend/src/components/MarketTableUser.js
+++ b/frontend/src/components/MarketTableUser.js
@@ -1,4 +1,5 @@
 import { DataGrid } from '@mui/x-data-grid'
+import Tooltip from '@mui/material/Tooltip'
 import { trendIcons, currencyFormatter, statusIcons } from './SharedConstants'
 
 // Import data
@@ -42,7 +43,11 @@ function MarketTableUser() {
             headerAlign: 'center',
             align: 'center',
             flex: 1,
-            renderCell: (params) => statusIcons[params.value]
+            renderCell: (params) => (
+                <Tooltip title={statusIcons[params.value].tooltip} arrow>
+                    {statusIcons[params.value].icon}
+                </Tooltip>
+            )
         },           
         {
             field: 'price',

--- a/frontend/src/components/SharedConstants.js
+++ b/frontend/src/components/SharedConstants.js
@@ -4,17 +4,11 @@ import TrendingDownIcon from '@mui/icons-material/TrendingDown'
 import TrendingUpIcon from '@mui/icons-material/TrendingUp'
 import TrendingFlatIcon from '@mui/icons-material/TrendingFlat'
 // Status Icons
-// # 0: Fit (Green Checkmark)
 import StatusFitIcon from '@mui/icons-material/CheckCircle'
-// # 1: Verletzt (Red Cross)
 import StatusVerletztIcon from '@mui/icons-material/Cancel'
-// # 2: Angeschlagen (bandage)
 import StatusAngeschlagenIcon from '@mui/icons-material/Healing'
-// # 4: Aufbautraining (Orange Cone)
-import StatusAufbautrainingIcon from '@mui/icons-material/Balance'
-// # TODO: Add "Raus aus der Liga"
-import StatusRausAusDerLiga from '@mui/icons-material/RemoveCircle'
-
+import StatusAufbautrainingIcon from '@mui/icons-material/Construction'
+import { StatusRedCardIcon, Status5YellowCardIcon } from '@mui/icons-material/Square'
 
 
 export const trendIcons = {
@@ -26,9 +20,11 @@ export const trendIcons = {
 export const statusIcons = {
     0: <StatusFitIcon sx={{ color: 'green' }} />,
     1: <StatusVerletztIcon sx={{ color: 'red' }} />,
-    2: <StatusAngeschlagenIcon sx={{ color: 'yellow' }} />,
-    4: <StatusAufbautrainingIcon sx={{ color: 'orange' }} />,
-    // 5: <StatusRausAusDerLiga sx={{ color: 'blue' }} />
+    2: <StatusAngeschlagenIcon sx={{ color: 'chocolate' }} />,
+    4: <StatusAufbautrainingIcon sx={{ color: 'brown' }} />,
+    // 5: <StatusRausAusDerLiga sx={{ color: 'blue' }} />,
+    8: <StatusRedCardIcon sx={{ color: "red" }} />,
+    32: <Status5YellowCardIcon sx={{ color: "gold" }} />,
 }
 
 export const currencyFormatter = new Intl.NumberFormat('de-DE',

--- a/frontend/src/components/SharedConstants.js
+++ b/frontend/src/components/SharedConstants.js
@@ -8,7 +8,8 @@ import StatusFitIcon from '@mui/icons-material/CheckCircle'
 import StatusVerletztIcon from '@mui/icons-material/Cancel'
 import StatusAngeschlagenIcon from '@mui/icons-material/Healing'
 import StatusAufbautrainingIcon from '@mui/icons-material/Construction'
-import { StatusRedCardIcon, Status5YellowCardIcon } from '@mui/icons-material/Square'
+import StatusRedCardIcon from '@mui/icons-material/Square'
+import Status5YellowCardIcon from '@mui/icons-material/Square'
 
 
 export const trendIcons = {
@@ -24,7 +25,7 @@ export const statusIcons = {
     4: <StatusAufbautrainingIcon sx={{ color: 'brown' }} />,
     // 5: <StatusRausAusDerLiga sx={{ color: 'blue' }} />,
     8: <StatusRedCardIcon sx={{ color: "red" }} />,
-    32: <Status5YellowCardIcon sx={{ color: "gold" }} />,
+    32: <Status5YellowCardIcon sx={{ color: "gold" }} />
 }
 
 export const currencyFormatter = new Intl.NumberFormat('de-DE',

--- a/frontend/src/components/SharedConstants.js
+++ b/frontend/src/components/SharedConstants.js
@@ -1,11 +1,34 @@
+// Material UI Icons
+// Trend Icons
 import TrendingDownIcon from '@mui/icons-material/TrendingDown'
 import TrendingUpIcon from '@mui/icons-material/TrendingUp'
 import TrendingFlatIcon from '@mui/icons-material/TrendingFlat'
+// Status Icons
+// # 0: Fit (Green Checkmark)
+import StatusFitIcon from '@mui/icons-material/CheckCircle'
+// # 1: Verletzt (Red Cross)
+import StatusVerletztIcon from '@mui/icons-material/Cancel'
+// # 2: Angeschlagen (bandage)
+import StatusAngeschlagenIcon from '@mui/icons-material/Healing'
+// # 4: Aufbautraining (Orange Cone)
+import StatusAufbautrainingIcon from '@mui/icons-material/Balance'
+// # TODO: Add "Raus aus der Liga"
+import StatusRausAusDerLiga from '@mui/icons-material/RemoveCircle'
+
+
 
 export const trendIcons = {
     0: <TrendingFlatIcon />,
     1: <TrendingUpIcon sx={{ color: 'green' }} />,
     2: <TrendingDownIcon sx={{ color: 'red' }} />
+}
+
+export const statusIcons = {
+    0: <StatusFitIcon sx={{ color: 'green' }} />,
+    1: <StatusVerletztIcon sx={{ color: 'red' }} />,
+    2: <StatusAngeschlagenIcon sx={{ color: 'yellow' }} />,
+    4: <StatusAufbautrainingIcon sx={{ color: 'orange' }} />,
+    // 5: <StatusRausAusDerLiga sx={{ color: 'blue' }} />
 }
 
 export const currencyFormatter = new Intl.NumberFormat('de-DE',

--- a/frontend/src/components/SharedConstants.js
+++ b/frontend/src/components/SharedConstants.js
@@ -11,21 +11,21 @@ import StatusAufbautrainingIcon from '@mui/icons-material/Construction'
 import StatusRedCardIcon from '@mui/icons-material/Square'
 import Status5YellowCardIcon from '@mui/icons-material/Square'
 
-
+// Set color for icons
 export const trendIcons = {
     0: <TrendingFlatIcon />,
     1: <TrendingUpIcon sx={{ color: 'green' }} />,
     2: <TrendingDownIcon sx={{ color: 'red' }} />
 }
 
+// Set color and tooltip for icons
 export const statusIcons = {
-    0: <StatusFitIcon sx={{ color: 'green' }} />,
-    1: <StatusVerletztIcon sx={{ color: 'red' }} />,
-    2: <StatusAngeschlagenIcon sx={{ color: 'chocolate' }} />,
-    4: <StatusAufbautrainingIcon sx={{ color: 'brown' }} />,
-    // 5: <StatusRausAusDerLiga sx={{ color: 'blue' }} />,
-    8: <StatusRedCardIcon sx={{ color: "red" }} />,
-    32: <Status5YellowCardIcon sx={{ color: "gold" }} />
+    0: { icon: <StatusFitIcon sx={{ color: 'green' }} />, tooltip: "Fit" },
+    1: { icon: <StatusVerletztIcon sx={{ color: 'red' }} />, tooltip: "Verletzt" },
+    2: { icon: <StatusAngeschlagenIcon sx={{ color: 'chocolate' }} />, tooltip: "Angeschlagen" },
+    4: { icon: <StatusAufbautrainingIcon sx={{ color: 'brown' }} />, tooltip: "Aufbautraining" },
+    8: { icon: <StatusRedCardIcon sx={{ color: "red" }} />, tooltip: "Rote Karte" },
+    32: { icon: <Status5YellowCardIcon sx={{ color: "gold" }} />, tooltip: "5. Gelbe Karte" }
 }
 
 export const currencyFormatter = new Intl.NumberFormat('de-DE',

--- a/frontend/src/components/TakenPlayersTable.js
+++ b/frontend/src/components/TakenPlayersTable.js
@@ -1,4 +1,5 @@
 import { DataGrid } from '@mui/x-data-grid'
+import Tooltip from '@mui/material/Tooltip'
 import { trendIcons, currencyFormatter, statusIcons } from './SharedConstants'
 import { Box } from '@mui/material'
 
@@ -34,7 +35,11 @@ function TakenPlayersTable() {
             headerAlign: 'center',
             align: 'center',
             flex: 1,
-            renderCell: (params) => statusIcons[params.value]
+            renderCell: (params) => (
+                <Tooltip title={statusIcons[params.value].tooltip} arrow>
+                    {statusIcons[params.value].icon}
+                </Tooltip>
+            )
         },        
         {
             field: 'buyPrice',

--- a/frontend/src/components/TakenPlayersTable.js
+++ b/frontend/src/components/TakenPlayersTable.js
@@ -1,5 +1,5 @@
 import { DataGrid } from '@mui/x-data-grid'
-import { trendIcons, currencyFormatter } from './SharedConstants'
+import { trendIcons, currencyFormatter, statusIcons } from './SharedConstants'
 import { Box } from '@mui/material'
 
 import data from '../data/taken_players.json'
@@ -28,6 +28,14 @@ function TakenPlayersTable() {
             align: 'center',
             flex: 2
         },
+        {
+            field: "status",
+            headerName: "Status",
+            headerAlign: 'center',
+            align: 'center',
+            flex: 1,
+            renderCell: (params) => statusIcons[params.value]
+        },        
         {
             field: 'buyPrice',
             headerName: 'Kaufpreis',
@@ -85,6 +93,7 @@ function TakenPlayersTable() {
             teamLogo: process.env.PUBLIC_URL + "/images/" + row.teamId + ".png",
             firstName: row.firstName,
             lastName: row.lastName,
+            status: row.status,
             buyPrice: row.buyPrice,
             marketValue: row.marketValue,
             turnover: row.buyPrice === 0 ? 0 : row.marketValue - row.buyPrice,

--- a/kickbase/leagues.py
+++ b/kickbase/leagues.py
@@ -223,6 +223,9 @@ def player_statistics(token: str, league_id: str, player_id: str):
     }
     ```
     The given attributes may change if the player is owned by a user!
+
+    #### Explanations:
+    nm = next match
     """
     url = f"https://api.kickbase.com/leagues/{league_id}/players/{player_id}/stats"
     headers = {

--- a/kickbase/miscellaneous.py
+++ b/kickbase/miscellaneous.py
@@ -137,6 +137,7 @@ def get_free_players(token: str, league_id: str, taken_players):
                     "lastName": player.p.lastName,
                     "marketValue": player.p.marketValue,
                     "trend": player.p.marketValueTrend,
+                    "status": player.p.status,
                     "points": player.p.totalPoints,
                 })
 

--- a/kickbase/miscellaneous.py
+++ b/kickbase/miscellaneous.py
@@ -25,6 +25,8 @@ POSITIONS = {1: 'TW', 2: 'ABW', 3: 'MF', 4: 'ANG'}
 # 1: Verletzt (Red Cross)
 # 2: Angeschlagen (bandage)
 # 4: Aufbautraining (Orange Cone)
+# 8: Rote Karte (Red Card)
+# 32: 5. Gelbe Karte (Yellow Card)
 # TODO: Add "Raus aus der Liga"
 
 ### TYPE (from league feed)

--- a/kickbase/miscellaneous.py
+++ b/kickbase/miscellaneous.py
@@ -13,8 +13,19 @@ from kickbase import exceptions, competition
 ### ===============================================================================
 
 POSITIONS = {1: 'TW', 2: 'ABW', 3: 'MF', 4: 'ANG'}
-### TREND?
-### STATUS
+
+### TREND (can be found via player stats)
+# 0: Gleichbleibend (500k player) (Welcher Zeitraum?)
+# 1: Steigt
+# 2: Sinkt
+### Conversion from number to icon for the frontend in "SharedConstants.js"
+
+### STATUS (can be found via player stats)
+# 0: Fit (Green Checkmark)
+# 1: Verletzt (Red Cross)
+# 2: Angeschlagen (bandage)
+# 4: Aufbautraining (Orange Cone)
+# TODO: Add "Raus aus der Liga"
 
 ### TYPE (from league feed)
 # Type 2: Verkauft an Kickbase

--- a/kickbase/miscellaneous.py
+++ b/kickbase/miscellaneous.py
@@ -28,6 +28,7 @@ POSITIONS = {1: 'TW', 2: 'ABW', 3: 'MF', 4: 'ANG'}
 # 8: Rote Karte (Red Card)
 # 32: 5. Gelbe Karte (Yellow Card)
 # TODO: Add "Raus aus der Liga"
+### Conversion from number to icon for the frontend in "SharedConstants.js"
 
 ### TYPE (from league feed)
 # Type 2: Verkauft an Kickbase

--- a/main.py
+++ b/main.py
@@ -341,6 +341,7 @@ def taken_free_players(user_token, league_info):
                 "lastName": transfer["meta"]["pln"],
                 "buyPrice": transfer["meta"]["p"],
                 "marketValue": player_stats["marketValue"],
+                "status": player_stats["status"],
                 "trend": player_stats["mvTrend"],
             })
 
@@ -375,6 +376,7 @@ def taken_free_players(user_token, league_info):
                     "lastName": player.p.lastName,
                     "buyPrice": 0,
                     "marketValue": player_stats["marketValue"],
+                    "status": player_stats["status"],
                     "trend": player_stats["mvTrend"],
                 })
 

--- a/main.py
+++ b/main.py
@@ -196,6 +196,7 @@ def market(user_token, league_info):
                 "firstName": f"{player.firstName}", 
                 "lastName": f"{player.lastName}",
                 "price": player.price,
+                "status": player.status,
                 "trend": player.marketValueTrend,
                 "expiration": (datetime.now() + timedelta(seconds=player.expiry)).strftime('%d.%m.%Y %H:%M:%S'),
             })
@@ -208,6 +209,7 @@ def market(user_token, league_info):
                 "firstName": f"{player.firstName}", 
                 "lastName": f"{player.lastName}",
                 "price": player.price,
+                "status": player.status,
                 "trend": player.marketValueTrend,
                 "seller": player.username,
                 "expiration": (datetime.now() + timedelta(seconds=player.expiry)).strftime('%d.%m.%Y %H:%M:%S'),


### PR DESCRIPTION
Frontend:
- Adds players status in "Transfermarkt (Kickbase)", "Transfermarkt (Spieler)", "Aufstellungsplaner", "Gebundene Spieler" and "Freie Spieler".

Backend:
- Adds the "status" dict in some JSON files to use it in the frontend.